### PR TITLE
Match ktlint_code_style with Ktlint documentation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Bump default `ktlint` version to latest `1.1.1` -> `1.2.1`. ([#2057](https://github.com/diffplug/spotless/pull/2057))
 * Bump default `sortpom` version to latest `3.4.0` -> `3.4.1`. ([#2078](https://github.com/diffplug/spotless/pull/2078))
 * **BREAKING** default `ktlint` editorconfig `ktlint_code_style` changed from `intellij_idea` to `ktlint_official` to better match the ktlint docs. ([#2090](https://github.com/diffplug/spotless/pull/2090))
-  - to keep the previous behavior of `intellij_idea`, you must set `ktlint_code_style = intellij_idea` in [.editconfig file](https://pinterest.github.io/ktlint/1.2.1/rules/code-styles/).
+  - to keep the previous behavior of `intellij_idea`, you must set `ktlint_code_style = intellij_idea` in [.editconfig file](https://pinterest.github.io/ktlint/1.2.1/rules/code-styles/) or ```.editorConfigOverride(
+    mapOf("ktlint_code_style" to "intellij_idea"))```
 ### Removed
 * **BREAKING** Remove `JarState.getMavenCoordinate(String prefix)`. ([#1945](https://github.com/diffplug/spotless/pull/1945))
 * **BREAKING** Replace `PipeStepPair` with `FenceStep`. ([#1954](https://github.com/diffplug/spotless/pull/1954))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Bump default `shfmt` version to latest `3.7.0` -> `3.8.0`. ([#2050](https://github.com/diffplug/spotless/pull/2050))
 * Bump default `ktlint` version to latest `1.1.1` -> `1.2.1`. ([#2057](https://github.com/diffplug/spotless/pull/2057))
 * Bump default `sortpom` version to latest `3.4.0` -> `3.4.1`. ([#2078](https://github.com/diffplug/spotless/pull/2078))
+* Default `ktlint` editorconfig `ktlint_code_style` to `intellij_idea` -> `ktlint_official`. ([#2090](https://github.com/diffplug/spotless/pull/2090))
 ### Removed
 * **BREAKING** Remove `JarState.getMavenCoordinate(String prefix)`. ([#1945](https://github.com/diffplug/spotless/pull/1945))
 * **BREAKING** Replace `PipeStepPair` with `FenceStep`. ([#1954](https://github.com/diffplug/spotless/pull/1954))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Bump default `shfmt` version to latest `3.7.0` -> `3.8.0`. ([#2050](https://github.com/diffplug/spotless/pull/2050))
 * Bump default `ktlint` version to latest `1.1.1` -> `1.2.1`. ([#2057](https://github.com/diffplug/spotless/pull/2057))
 * Bump default `sortpom` version to latest `3.4.0` -> `3.4.1`. ([#2078](https://github.com/diffplug/spotless/pull/2078))
-* Default `ktlint` editorconfig `ktlint_code_style` to `intellij_idea` -> `ktlint_official`. ([#2090](https://github.com/diffplug/spotless/pull/2090))
+* **BREAKING** default `ktlint` editorconfig `ktlint_code_style` changed from `intellij_idea` to `ktlint_official` to better match the ktlint docs. ([#2090](https://github.com/diffplug/spotless/pull/2090))
+  - to keep the previous behavior of `intellij_idea`, you must set `ktlint_code_style = intellij_idea` in [.editconfig file](https://pinterest.github.io/ktlint/1.2.1/rules/code-styles/).
 ### Removed
 * **BREAKING** Remove `JarState.getMavenCoordinate(String prefix)`. ([#1945](https://github.com/diffplug/spotless/pull/1945))
 * **BREAKING** Replace `PipeStepPair` with `FenceStep`. ([#1954](https://github.com/diffplug/spotless/pull/1954))

--- a/lib/src/compatKtLint1Dot0Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat1Dot0Dot0Adapter.java
+++ b/lib/src/compatKtLint1Dot0Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat1Dot0Dot0Adapter.java
@@ -131,11 +131,6 @@ public class KtLintCompat1Dot0Dot0Adapter implements KtLintCompatAdapter {
 				.distinct()
 				.collect(Collectors.toMap(EditorConfigProperty::getName, property -> property));
 
-		// The default style had been changed from intellij_idea to ktlint_official in version 1.0.0
-		if (!editorConfigOverrideMap.containsKey("ktlint_code_style")) {
-			editorConfigOverrideMap.put("ktlint_code_style", "ktlint_official");
-		}
-
 		// Create config properties based on provided property names and values
 		@SuppressWarnings("unchecked")
 		Pair<EditorConfigProperty<?>, ?>[] properties = editorConfigOverrideMap.entrySet().stream()

--- a/lib/src/compatKtLint1Dot0Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat1Dot0Dot0Adapter.java
+++ b/lib/src/compatKtLint1Dot0Dot0/java/com/diffplug/spotless/glue/ktlint/compat/KtLintCompat1Dot0Dot0Adapter.java
@@ -133,7 +133,7 @@ public class KtLintCompat1Dot0Dot0Adapter implements KtLintCompatAdapter {
 
 		// The default style had been changed from intellij_idea to ktlint_official in version 1.0.0
 		if (!editorConfigOverrideMap.containsKey("ktlint_code_style")) {
-			editorConfigOverrideMap.put("ktlint_code_style", "intellij_idea");
+			editorConfigOverrideMap.put("ktlint_code_style", "ktlint_official");
 		}
 
 		// Create config properties based on provided property names and values

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -13,6 +13,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Bump default `shfmt` version to latest `3.7.0` -> `3.8.0`. ([#2050](https://github.com/diffplug/spotless/pull/2050))
 * Bump default `ktlint` version to latest `1.1.1` -> `1.2.1`. ([#2057](https://github.com/diffplug/spotless/pull/2057))
 * Bump default `sortpom` version to latest `3.4.0` -> `3.4.1`. ([#2078](https://github.com/diffplug/spotless/pull/2078))
+* **BREAKING** default `ktlint` editorconfig `ktlint_code_style` changed from `intellij_idea` to `ktlint_official` to better match the ktlint docs. ([#2090](https://github.com/diffplug/spotless/pull/2090))
+  - to keep the previous behavior of `intellij_idea`, you must set `ktlint_code_style = intellij_idea` in [.editconfig file](https://pinterest.github.io/ktlint/1.2.1/rules/code-styles/).
 ### Added
 * Respect `.editorconfig` settings for formatting shell via `shfmt` ([#2031](https://github.com/diffplug/spotless/pull/2031))
 * Add support for formatting and sorting Maven POMs ([#2082](https://github.com/diffplug/spotless/issues/2082))

--- a/plugin-gradle/CHANGES.md
+++ b/plugin-gradle/CHANGES.md
@@ -14,7 +14,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Bump default `ktlint` version to latest `1.1.1` -> `1.2.1`. ([#2057](https://github.com/diffplug/spotless/pull/2057))
 * Bump default `sortpom` version to latest `3.4.0` -> `3.4.1`. ([#2078](https://github.com/diffplug/spotless/pull/2078))
 * **BREAKING** default `ktlint` editorconfig `ktlint_code_style` changed from `intellij_idea` to `ktlint_official` to better match the ktlint docs. ([#2090](https://github.com/diffplug/spotless/pull/2090))
-  - to keep the previous behavior of `intellij_idea`, you must set `ktlint_code_style = intellij_idea` in [.editconfig file](https://pinterest.github.io/ktlint/1.2.1/rules/code-styles/).
+  - to keep the previous behavior of `intellij_idea`, you must set `ktlint_code_style = intellij_idea` in [.editconfig file](https://pinterest.github.io/ktlint/1.2.1/rules/code-styles/) or ```.editorConfigOverride(
+    mapOf("ktlint_code_style" to "intellij_idea"))```
 ### Added
 * Respect `.editorconfig` settings for formatting shell via `shfmt` ([#2031](https://github.com/diffplug/spotless/pull/2031))
 * Add support for formatting and sorting Maven POMs ([#2082](https://github.com/diffplug/spotless/issues/2082))

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
@@ -22,6 +22,9 @@ import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
 
+/**
+ * Unit test for {@link KotlinExtension}
+ */
 class KotlinExtensionTest extends GradleIntegrationHarness {
 	private static final String HEADER = "// License Header";
 	private static final String HEADER_WITH_YEAR = "// License Header $YEAR";

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinExtensionTest.java
@@ -71,7 +71,7 @@ class KotlinExtensionTest extends GradleIntegrationHarness {
 	}
 
 	@Test
-	void withExperimentalEditorConfigOverride() throws IOException {
+	void editorConfigOverride_setExperimental_intellijIdeaStyle() throws IOException {
 		setFile("build.gradle").toLines(
 				"plugins {",
 				"    id 'org.jetbrains.kotlin.jvm' version '1.6.21'",
@@ -82,6 +82,7 @@ class KotlinExtensionTest extends GradleIntegrationHarness {
 				"    kotlin {",
 				"        ktlint().editorConfigOverride([",
 				"            ktlint_experimental: \"enabled\",",
+				"            ktlint_code_style : \"intellij_idea\",",
 				"            ij_kotlin_allow_trailing_comma: true,",
 				"            ij_kotlin_allow_trailing_comma_on_call_site: true",
 				"        ])",
@@ -90,6 +91,28 @@ class KotlinExtensionTest extends GradleIntegrationHarness {
 		setFile("src/main/kotlin/Main.kt").toResource("kotlin/ktlint/experimentalEditorConfigOverride.dirty");
 		gradleRunner().withArguments("spotlessApply").build();
 		assertFile("src/main/kotlin/Main.kt").sameAsResource("kotlin/ktlint/experimentalEditorConfigOverride.clean");
+	}
+
+	@Test
+	void editorConfigOverride_setExperimental_defaultKtlintOfficialStyle() throws IOException {
+		setFile("build.gradle").toLines(
+			"plugins {",
+			"    id 'org.jetbrains.kotlin.jvm' version '1.6.21'",
+			"    id 'com.diffplug.spotless'",
+			"}",
+			"repositories { mavenCentral() }",
+			"spotless {",
+			"    kotlin {",
+			"        ktlint().editorConfigOverride([",
+			"            ktlint_experimental: \"enabled\",",
+			"            ij_kotlin_allow_trailing_comma: true,",
+			"            ij_kotlin_allow_trailing_comma_on_call_site: true",
+			"        ])",
+			"    }",
+			"}");
+		setFile("src/main/kotlin/Main.kt").toResource("kotlin/ktlint/experimentalEditorConfigOverride.dirty");
+		gradleRunner().withArguments("spotlessApply").build();
+		assertFile("src/main/kotlin/Main.kt").sameAsResource("kotlin/ktlint/experimentalEditorConfigOverride.ktlintOfficial.clean");
 	}
 
 	@Test

--- a/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinGradleExtensionTest.java
+++ b/plugin-gradle/src/test/java/com/diffplug/gradle/spotless/KotlinGradleExtensionTest.java
@@ -27,7 +27,7 @@ class KotlinGradleExtensionTest extends KotlinExtensionTest {
 
 	@ParameterizedTest
 	@ValueSource(booleans = {true, false})
-	void testTarget(boolean useDefaultTarget) throws IOException {
+	void target_setAndUnset_intellijIdeaStyle(boolean useDefaultTarget) throws IOException {
 		setFile("build.gradle").toLines(
 				"plugins {",
 				"    id 'org.jetbrains.kotlin.jvm' version '1.6.21'",
@@ -39,6 +39,7 @@ class KotlinGradleExtensionTest extends KotlinExtensionTest {
 				"        " + (useDefaultTarget ? "" : "target \"*.kts\""),
 				"        ktlint().editorConfigOverride([",
 				"            ktlint_experimental: \"enabled\",",
+				"            ktlint_code_style: \"intellij_idea\",",
 				"            ij_kotlin_allow_trailing_comma: true,",
 				"            ij_kotlin_allow_trailing_comma_on_call_site: true",
 				"        ])",
@@ -53,6 +54,37 @@ class KotlinGradleExtensionTest extends KotlinExtensionTest {
 		} else {
 			assertFile("configuration.gradle.kts").sameAsResource("kotlin/ktlint/experimentalEditorConfigOverride.clean");
 			assertFile("configuration.kts").sameAsResource("kotlin/ktlint/experimentalEditorConfigOverride.clean");
+		}
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	void target_setAndUnset_defaultKtlintOfficialStyle(boolean useDefaultTarget) throws IOException {
+		setFile("build.gradle").toLines(
+			"plugins {",
+			"    id 'org.jetbrains.kotlin.jvm' version '1.6.21'",
+			"    id 'com.diffplug.spotless'",
+			"}",
+			"repositories { mavenCentral() }",
+			"spotless {",
+			"    kotlinGradle {",
+			"        " + (useDefaultTarget ? "" : "target \"*.kts\""),
+			"        ktlint().editorConfigOverride([",
+			"            ktlint_experimental: \"enabled\",",
+			"            ij_kotlin_allow_trailing_comma: true,",
+			"            ij_kotlin_allow_trailing_comma_on_call_site: true",
+			"        ])",
+			"    }",
+			"}");
+		setFile("configuration.gradle.kts").toResource("kotlin/ktlint/experimentalEditorConfigOverride.dirty");
+		setFile("configuration.kts").toResource("kotlin/ktlint/experimentalEditorConfigOverride.dirty");
+		gradleRunner().withArguments("spotlessApply").build();
+		if (useDefaultTarget) {
+			assertFile("configuration.gradle.kts").sameAsResource("kotlin/ktlint/experimentalEditorConfigOverride.ktlintOfficial.clean");
+			assertFile("configuration.kts").sameAsResource("kotlin/ktlint/experimentalEditorConfigOverride.dirty");
+		} else {
+			assertFile("configuration.gradle.kts").sameAsResource("kotlin/ktlint/experimentalEditorConfigOverride.ktlintOfficial.clean");
+			assertFile("configuration.kts").sameAsResource("kotlin/ktlint/experimentalEditorConfigOverride.ktlintOfficial.clean");
 		}
 	}
 }

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -13,7 +13,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Bump default `ktlint` version to latest `1.1.1` -> `1.2.1`. ([#2057](https://github.com/diffplug/spotless/pull/2057))
 * Bump default `sortpom` version to latest `3.4.0` -> `3.4.1`. ([#2078](https://github.com/diffplug/spotless/pull/2078))
 * **BREAKING** default `ktlint` editorconfig `ktlint_code_style` changed from `intellij_idea` to `ktlint_official` to better match the ktlint docs. ([#2090](https://github.com/diffplug/spotless/pull/2090))
-  - to keep the previous behavior of `intellij_idea`, you must set `ktlint_code_style = intellij_idea` in [.editconfig file](https://pinterest.github.io/ktlint/1.2.1/rules/code-styles/).
+  - to keep the previous behavior of `intellij_idea`, you must set `ktlint_code_style = intellij_idea` in [.editconfig file](https://pinterest.github.io/ktlint/1.2.1/rules/code-styles/) or ```.editorConfigOverride(
+    mapOf("ktlint_code_style" to "intellij_idea"))```
 ### Added
 * Respect `.editorconfig` settings for formatting shell via `shfmt` ([#2031](https://github.com/diffplug/spotless/pull/2031))
 * Skip execution in M2E (incremental) builds by default ([#1814](https://github.com/diffplug/spotless/issues/1814), [#2037](https://github.com/diffplug/spotless/issues/2037)) 

--- a/plugin-maven/CHANGES.md
+++ b/plugin-maven/CHANGES.md
@@ -12,6 +12,8 @@ We adhere to the [keepachangelog](https://keepachangelog.com/en/1.0.0/) format (
 * Bump default `shfmt` version to latest `3.7.0` -> `3.8.0`. ([#2050](https://github.com/diffplug/spotless/pull/2050))
 * Bump default `ktlint` version to latest `1.1.1` -> `1.2.1`. ([#2057](https://github.com/diffplug/spotless/pull/2057))
 * Bump default `sortpom` version to latest `3.4.0` -> `3.4.1`. ([#2078](https://github.com/diffplug/spotless/pull/2078))
+* **BREAKING** default `ktlint` editorconfig `ktlint_code_style` changed from `intellij_idea` to `ktlint_official` to better match the ktlint docs. ([#2090](https://github.com/diffplug/spotless/pull/2090))
+  - to keep the previous behavior of `intellij_idea`, you must set `ktlint_code_style = intellij_idea` in [.editconfig file](https://pinterest.github.io/ktlint/1.2.1/rules/code-styles/).
 ### Added
 * Respect `.editorconfig` settings for formatting shell via `shfmt` ([#2031](https://github.com/diffplug/spotless/pull/2031))
 * Skip execution in M2E (incremental) builds by default ([#1814](https://github.com/diffplug/spotless/issues/1814), [#2037](https://github.com/diffplug/spotless/issues/2037)) 

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/KtlintTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/KtlintTest.java
@@ -22,6 +22,9 @@ import org.junit.jupiter.api.Test;
 import com.diffplug.spotless.ProcessRunner;
 import com.diffplug.spotless.maven.MavenIntegrationHarness;
 
+/**
+ * Unit test for {@link Ktlint}
+ */
 class KtlintTest extends MavenIntegrationHarness {
 	@Test
 	void testKtlint() throws Exception {

--- a/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/KtlintTest.java
+++ b/plugin-maven/src/test/java/com/diffplug/spotless/maven/kotlin/KtlintTest.java
@@ -37,7 +37,22 @@ class KtlintTest extends MavenIntegrationHarness {
 	}
 
 	@Test
-	void testKtlintEditorConfigOverride() throws Exception {
+	void writePomWithKotlinSteps_intellijIdea_intellijIdeaStyleKtlint() throws Exception {
+		writePomWithKotlinSteps("<ktlint>\n" +
+			"  <editorConfigOverride>\n" +
+			"    <ktlint_code_style>intellij_idea</ktlint_code_style>" +
+			"    <ij_kotlin_allow_trailing_comma>true</ij_kotlin_allow_trailing_comma>\n" +
+			"    <ij_kotlin_allow_trailing_comma_on_call_site>true</ij_kotlin_allow_trailing_comma_on_call_site>\n" +
+			"  </editorConfigOverride>\n" +
+			"</ktlint>");
+
+		String path = "src/main/kotlin/Main.kt";
+		setFile(path).toResource("kotlin/ktlint/experimentalEditorConfigOverride.dirty");
+		mavenRunner().withArguments("spotless:apply").runNoError();
+		assertFile(path).sameAsResource("kotlin/ktlint/experimentalEditorConfigOverride.clean");
+	}
+	@Test
+	void writePomWithKotlinSteps_default_officialStyleKtlint() throws Exception {
 		writePomWithKotlinSteps("<ktlint>\n" +
 				"  <editorConfigOverride>\n" +
 				"    <ij_kotlin_allow_trailing_comma>true</ij_kotlin_allow_trailing_comma>\n" +
@@ -45,10 +60,7 @@ class KtlintTest extends MavenIntegrationHarness {
 				"  </editorConfigOverride>\n" +
 				"</ktlint>");
 
-		String path = "src/main/kotlin/Main.kt";
-		setFile(path).toResource("kotlin/ktlint/experimentalEditorConfigOverride.dirty");
-		mavenRunner().withArguments("spotless:apply").runNoError();
-		assertFile(path).sameAsResource("kotlin/ktlint/experimentalEditorConfigOverride.clean");
+		checkKtlintOfficialStyle();
 	}
 
 	@Test


### PR DESCRIPTION
[Ktlint document](https://pinterest.github.io/ktlint/1.0.0/rules/code-styles/) says that 
> Starting from version 1.0, ktlint_official is the default code style. If you want to revert to another code style, then set the .editorconfig property ktlint_code_style.

But Spotless default set ```intellij_idea``` It makes developer mistake and misconception.

According Ktlint documentation, only one want to revert another code style must set the ktlint_code_style, but in Spotless need to  set the ktlint_code_style who want to apply ```ktlint_official``` or ```else``` styles.

diffplug/spotless#2090

<!--
After creating the PR, please add a commit that adds a bullet-point under the `[Unreleased]` section of [CHANGES.md](https://github.com/diffplug/spotless/blob/main/CHANGES.md), [plugin-gradle/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md), and [plugin-maven/CHANGES.md](https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md) which includes:


- [ ] a summary of the change
- either
    - [ ] a link to the issue you are resolving (for small changes)
    - [ ] a link to the PR you just created (for big changes likely to have discussion)

If your change only affects a build plugin, and not the lib, then you only need to update the `plugin-foo/CHANGES.md` for that plugin.

If your change affects lib in an end-user-visible way (fixing a bug, updating a version) then you need to update `CHANGES.md` for both the lib and all build plugins.  Users of a build plugin shouldn't have to refer to lib to see changes that affect them.

This makes it easier for the maintainers to quickly release your changes :)
-->
